### PR TITLE
Update webpackage.config.js to enable hot loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
     filename: 'bundle.js'
   },
   devServer: {
+    hot: true,
     contentBase: './public',
     publicPath: 'http://localhost:8080/built'
   },


### PR DESCRIPTION
Hot loader doesn't work until I added `hot: true` option to the `devServer`.